### PR TITLE
Merge develop: SSE, make-now, custom filters, coverage audit

### DIFF
--- a/morsl/app/api/dependencies.py
+++ b/morsl/app/api/dependencies.py
@@ -102,7 +102,7 @@ def resolve_credentials(settings: Settings, settings_svc: SettingsService) -> tu
     if url and token_b64:
         try:
             token = base64.b64decode(token_b64).decode()
-        except Exception:
+        except (ValueError, UnicodeDecodeError):
             raise HTTPException(500, "Stored Tandoor token is corrupt (invalid base64)") from None
         return url, token
     raise HTTPException(500, "TANDOOR_URL and TANDOOR_TOKEN must be configured")

--- a/morsl/app/api/routes/custom_icons.py
+++ b/morsl/app/api/routes/custom_icons.py
@@ -35,7 +35,7 @@ async def upload_custom_icon(
         )
     try:
         result = svc.save_icon(file.filename, content)
-    except Exception as e:
+    except (ValueError, OSError) as e:
         raise HTTPException(status_code=400, detail=f"Invalid SVG: {e}") from None
     return result
 

--- a/morsl/app/api/routes/menu.py
+++ b/morsl/app/api/routes/menu.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import asyncio
+import json
+
 from fastapi import APIRouter, Depends, HTTPException
+from starlette.responses import StreamingResponse
 
 from morsl.app.api.dependencies import get_generation_service, require_admin
 from morsl.app.api.models import GenerationStatusResponse, MenuResponse
+from morsl.constants import SSE_QUEUE_TIMEOUT
 from morsl.services.generation_service import GenerationService
 
 router = APIRouter(tags=["menu"])
@@ -42,4 +47,38 @@ def get_status(
         error=status.error,
         recipe_count=status.recipe_count,
         warnings=status.warnings,
+    )
+
+
+@router.get("/menu/stream")
+async def menu_stream(
+    gen_service: GenerationService = Depends(get_generation_service),
+) -> StreamingResponse:
+    """SSE stream for real-time menu change notifications.
+
+    Events:
+    - generating: generation started
+    - menu_updated: new menu available
+    - menu_cleared: menu was deleted
+    """
+    queue = gen_service.subscribe()
+
+    async def event_generator():
+        try:
+            yield "event: connected\ndata: {}\n\n"
+            while True:
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=SSE_QUEUE_TIMEOUT)
+                    yield f"event: {event['type']}\ndata: {json.dumps(event)}\n\n"
+                except asyncio.TimeoutError:
+                    yield ": keepalive\n\n"
+        except asyncio.CancelledError:
+            pass
+        finally:
+            gen_service.unsubscribe(queue)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )

--- a/morsl/app/api/routes/profiles.py
+++ b/morsl/app/api/routes/profiles.py
@@ -145,12 +145,12 @@ def preview_profile(
     config["cache"] = settings_svc.get_all().get("api_cache_minutes", API_CACHE_TTL_MINUTES)
 
     try:
-        service = MenuService(url=url, token=token, config=config, logger=logger)
+        service = MenuService(url=url, token=token, config=config, logger=logger)  # noqa: direct-service — preview creates one-off service with request-scoped config
         service.prepare_data()
         return {
             "matching_count": len(service.recipes),
             "choices": config.get("choices", DEFAULT_CHOICES),
         }
-    except Exception as e:
+    except (OSError, ValueError, KeyError) as e:
         logger.warning(f"Preview failed: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from None

--- a/morsl/app/api/routes/proxy.py
+++ b/morsl/app/api/routes/proxy.py
@@ -188,7 +188,7 @@ def set_rating(
     }
     try:
         requests.post(cook_log_url, headers=headers, json=cook_log_data, timeout=DEFAULT_TIMEOUT)
-    except Exception as e:
+    except requests.RequestException as e:
         logger.warning(f"Failed to create cook log for recipe {recipe_id}: {e}")
 
     if response.content:

--- a/morsl/app/api/routes/settings.py
+++ b/morsl/app/api/routes/settings.py
@@ -184,7 +184,7 @@ async def test_connection(body: CredentialRequest) -> Dict[str, Any]:
         return {"success": False, "error": f"HTTP {resp.status_code}"}
     except httpx.TimeoutException:
         return {"success": False, "error": "Connection timed out"}
-    except Exception as e:
+    except (httpx.HTTPError, OSError) as e:
         logger.warning("test-connection failed for %s: %s", url, e)
         return {"success": False, "error": "Connection failed"}
 
@@ -229,7 +229,7 @@ def _save_upload(file: UploadFile, prefix: str) -> str:
         os.close(fd)
         closed = True
         os.replace(tmp_path, str(dest))
-    except Exception:
+    except OSError:
         if not closed:
             os.close(fd)
         if os.path.exists(tmp_path):
@@ -283,7 +283,7 @@ def upload_favicon(
 
         generate_icons(source_path, ICONS_DIR)
         logger.info("Regenerated icons from %s", source_path)
-    except Exception as e:
+    except (OSError, ValueError) as e:
         logger.error("Icon generation failed: %s", e)
         raise HTTPException(500, f"Icon generation failed: {e}") from None
 
@@ -304,7 +304,7 @@ def remove_favicon(
             from morsl.services.icon_service import generate_icons
 
             generate_icons(default_svg, ICONS_DIR)
-        except Exception as e:
+        except (OSError, ValueError) as e:
             logger.warning("Default icon regeneration failed: %s", e)
 
     return svc.update({"favicon_url": ""})
@@ -346,7 +346,7 @@ def reset_branding(
             from morsl.services.icon_service import generate_icons
 
             generate_icons(DEFAULT_FAVICON_PATH, ICONS_DIR)
-        except Exception as e:
+        except (OSError, ValueError) as e:
             logger.warning("Default icon regeneration failed: %s", e)
 
     # Reset branding settings to defaults
@@ -370,7 +370,7 @@ def _reset_step(errors: list, label: str, fn) -> None:
     """Run a factory reset step, collecting errors instead of raising."""
     try:
         fn()
-    except Exception as e:
+    except Exception as e:  # noqa: broad-except — error collection during factory reset
         errors.append(f"{label}: {e}")
 
 

--- a/morsl/app/main.py
+++ b/morsl/app/main.py
@@ -204,7 +204,6 @@ def _setup_scheduler(settings) -> None:
     ) = _build_scheduler_callbacks(settings)
 
     scheduler_svc.set_generation_callback(gen_cb)
-    scheduler_svc.set_clear_callback(get_generation_service(settings).clear_menu)
     scheduler_svc.set_meal_plan_callback(meal_plan_cb)
     scheduler_svc.set_weekly_generation_callback(weekly_gen_cb)
     scheduler_svc.set_weekly_save_callback(weekly_save_cb)

--- a/morsl/app/main.py
+++ b/morsl/app/main.py
@@ -94,7 +94,7 @@ def _resolve_scheduler_services(settings):
     return settings_svc, get_logger(settings), url, token
 
 
-async def _sched_generation(settings, profile: str) -> None:
+async def _sched_generation(settings, profile: str, *, clear_others: bool = False) -> None:
     try:
         _, app_logger, url, token = _resolve_scheduler_services(settings)
         config = get_config_service(settings).load_profile(profile)
@@ -104,6 +104,7 @@ async def _sched_generation(settings, profile: str) -> None:
             url=url,
             token=token,
             logger=app_logger,
+            clear_others=clear_others,
         )
         await gen_svc.wait_for_completion()
     except Exception:  # noqa: broad-except — scheduled task isolation
@@ -182,7 +183,7 @@ async def _sched_weekly_save(settings, template_name: str) -> None:
 def _build_scheduler_callbacks(settings):
     """Create bound callback functions for the scheduler service."""
     return (
-        lambda profile: _sched_generation(settings, profile),
+        lambda profile, **kw: _sched_generation(settings, profile, **kw),
         lambda action, params: _sched_meal_plan(settings, action, params),
         lambda template_name, week_start=None: _sched_weekly_generation(
             settings,

--- a/morsl/app/main.py
+++ b/morsl/app/main.py
@@ -69,7 +69,7 @@ def _generate_startup_icons(settings) -> None:
         if source.exists():
             generate_icons(source, icons_dir)
             logger.info("Generated startup icons from %s", source)
-    except Exception as e:
+    except (OSError, ValueError) as e:
         logger.warning("Startup icon generation failed (non-fatal): %s", e)
 
 
@@ -106,7 +106,7 @@ async def _sched_generation(settings, profile: str) -> None:
             logger=app_logger,
         )
         await gen_svc.wait_for_completion()
-    except Exception:
+    except Exception:  # noqa: broad-except — scheduled task isolation
         logger.warning(
             "Scheduled generation failed for profile '%s'",
             profile,
@@ -154,7 +154,7 @@ async def _sched_weekly_generation(
             settings_service=settings_svc,
         )
         await get_weekly_generation_service(settings).wait_for_completion()
-    except Exception:
+    except Exception:  # noqa: broad-except — scheduled task isolation
         logger.warning(
             "Scheduled weekly generation failed for '%s'",
             template_name,
@@ -175,7 +175,7 @@ async def _sched_weekly_save(settings, template_name: str) -> None:
             weekly_plan=plan,
             shared=[],
         )
-    except Exception:
+    except (OSError, ValueError, KeyError):
         logger.warning("Scheduled weekly save failed (non-fatal)", exc_info=True)
 
 
@@ -216,19 +216,19 @@ async def _shutdown_services(settings) -> None:
     try:
         gen_service = get_generation_service(settings)
         await gen_service.shutdown(timeout=GENERATION_SHUTDOWN_TIMEOUT)
-    except Exception:
+    except Exception:  # noqa: broad-except — shutdown must not abort
         logger.warning("Error during shutdown cleanup", exc_info=True)
 
     try:
         weekly_gen_service = get_weekly_generation_service(settings)
         await weekly_gen_service.shutdown(timeout=GENERATION_SHUTDOWN_TIMEOUT)
-    except Exception:
+    except Exception:  # noqa: broad-except — shutdown must not abort
         logger.warning("Weekly generation shutdown error", exc_info=True)
 
     try:
         scheduler_svc = get_scheduler_service(settings)
         scheduler_svc.stop()
-    except Exception:
+    except Exception:  # noqa: broad-except — shutdown must not abort
         logger.warning("Scheduler shutdown error", exc_info=True)
 
 
@@ -245,7 +245,7 @@ async def lifespan(app: FastAPI):
 
     try:
         _setup_scheduler(settings)
-    except Exception:
+    except Exception:  # noqa: broad-except — non-fatal startup
         logger.warning("Scheduler startup failed (non-fatal)", exc_info=True)
 
     yield
@@ -299,7 +299,7 @@ def health_check(
 
     try:
         scheduler_running = scheduler.is_running
-    except Exception:
+    except Exception:  # noqa: broad-except — health check must not fail
         scheduler_running = False
 
     return {

--- a/morsl/services/generation_service.py
+++ b/morsl/services/generation_service.py
@@ -151,7 +151,7 @@ class GenerationService:
                     }
                 )
 
-        except Exception as e:
+        except Exception as e:  # noqa: broad-except — state machine must capture any failure
             logger.warning("Menu generation failed", exc_info=True)
             self._status.state = GenerationState.ERROR
             self._status.completed_at = now()

--- a/morsl/services/generation_service.py
+++ b/morsl/services/generation_service.py
@@ -68,7 +68,7 @@ class GenerationService:
             return json.load(f)
 
     def clear_menu(self) -> bool:
-        """Delete current_menu.json. Returns True if a file was removed."""
+        """Delete current_menu.json and clear cache. Returns True if a file was removed."""
         self._cached_menu = None
         menu_path = os.path.join(self.data_dir, "current_menu.json")
         if os.path.isfile(menu_path):

--- a/morsl/services/generation_service.py
+++ b/morsl/services/generation_service.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import json
 import os
+import threading
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -48,6 +49,8 @@ class GenerationService:
         self._current_task: Optional[asyncio.Task[None]] = None
         self._lock = asyncio.Lock()
         self._cached_menu: Optional[Dict[str, Any]] = None
+        self._subscribers: List[asyncio.Queue[Dict[str, Any]]] = []
+        self._sub_lock = threading.Lock()
         self._cleanup_stale_temp_files()
         # Load menu into cache on startup
         self._cached_menu = self._load_menu_from_disk()
@@ -73,6 +76,7 @@ class GenerationService:
         menu_path = os.path.join(self.data_dir, "current_menu.json")
         if os.path.isfile(menu_path):
             os.unlink(menu_path)
+            self._notify_subscribers({"type": "menu_cleared"})
             return True
         return False
 
@@ -83,6 +87,7 @@ class GenerationService:
         token: str,
         logger: Logger,
         profile_name: str = "default",
+        clear_others: bool = False,
     ) -> str:
         """Start menu generation in the background. Returns request_id."""
         async with self._lock:
@@ -95,10 +100,13 @@ class GenerationService:
                 request_id=request_id,
                 started_at=now(),
             )
+            self._notify_subscribers({"type": "generating"})
 
             loop = asyncio.get_running_loop()
             self._current_task = loop.create_task(
-                self._run_generation(config, url, token, logger, request_id, profile_name)
+                self._run_generation(
+                    config, url, token, logger, request_id, profile_name, clear_others
+                )
             )
             return request_id
 
@@ -110,6 +118,7 @@ class GenerationService:
         logger: Logger,
         request_id: str,
         profile_name: str = "default",
+        clear_others: bool = False,
     ) -> None:
         """Run the solver in a thread pool and save results."""
         try:
@@ -121,7 +130,7 @@ class GenerationService:
             result["profile"] = profile_name
 
             # Save to disk atomically
-            self._save_menu(result)
+            self._save_menu(result, clear_others=clear_others)
 
             self._status.state = GenerationState.COMPLETE
             self._status.completed_at = now()
@@ -239,8 +248,28 @@ class GenerationService:
                 with contextlib.suppress(OSError):
                     os.unlink(os.path.join(self.data_dir, fname))
 
-    def _save_menu(self, menu_data: Dict[str, Any]) -> None:
+    def subscribe(self) -> asyncio.Queue[Dict[str, Any]]:
+        """Create a new SSE subscriber queue for menu change events."""
+        q: asyncio.Queue[Dict[str, Any]] = asyncio.Queue(maxsize=64)
+        with self._sub_lock:
+            self._subscribers.append(q)
+        return q
+
+    def unsubscribe(self, q: asyncio.Queue[Dict[str, Any]]) -> None:
+        """Remove subscriber queue."""
+        with self._sub_lock, contextlib.suppress(ValueError):
+            self._subscribers.remove(q)
+
+    def _notify_subscribers(self, event: Dict[str, Any]) -> None:
+        """Push event to all SSE subscribers (non-blocking)."""
+        with self._sub_lock:
+            for q in self._subscribers:
+                with contextlib.suppress(asyncio.QueueFull):
+                    q.put_nowait(event)
+
+    def _save_menu(self, menu_data: Dict[str, Any], *, clear_others: bool = False) -> None:
         """Atomic write and update in-memory cache."""
         menu_path = os.path.join(self.data_dir, "current_menu.json")
         atomic_write_json(menu_path, menu_data)
         self._cached_menu = menu_data
+        self._notify_subscribers({"type": "menu_updated", "clear_others": clear_others})

--- a/morsl/services/recipe_detail_service.py
+++ b/morsl/services/recipe_detail_service.py
@@ -20,7 +20,7 @@ def _resolve_food(api: TandoorAPI, food_obj: dict, logger: Logger) -> dict:
             return api.get_food(random.choice(subs)["id"])
     except (KeyError, IndexError, TypeError) as e:
         logger.debug("Substitute lookup failed for food %s: %s", food_obj.get("id"), e)
-    except Exception as e:
+    except OSError as e:  # RequestException inherits IOError/OSError
         logger.warning(
             "Unexpected error in substitute lookup for food %s: %s", food_obj.get("id"), e
         )

--- a/morsl/services/scheduler_service.py
+++ b/morsl/services/scheduler_service.py
@@ -221,7 +221,7 @@ class SchedulerService:
                         "cleanup_days": cleanup_days,
                     },
                 )
-            except Exception:
+            except Exception:  # noqa: broad-except — non-fatal scheduled task
                 logger.warning(
                     "Scheduled cleanup failed (non-fatal)",
                     exc_info=True,
@@ -242,7 +242,7 @@ class SchedulerService:
         if schedule.get("create_meal_plan") and self._weekly_save_callback:
             try:
                 await self._weekly_save_callback(template_name)
-            except Exception:
+            except Exception:  # noqa: broad-except — non-fatal scheduled task
                 logger.warning(
                     "Scheduled weekly save failed (non-fatal)",
                     exc_info=True,
@@ -257,7 +257,7 @@ class SchedulerService:
         if schedule.get("create_meal_plan") and mp_type and self._meal_plan_callback:
             try:
                 await self._meal_plan_callback("create", {"meal_plan_type": mp_type})
-            except Exception:
+            except Exception:  # noqa: broad-except — non-fatal scheduled task
                 logger.warning(
                     "Scheduled meal plan creation failed (non-fatal)",
                     exc_info=True,

--- a/morsl/services/scheduler_service.py
+++ b/morsl/services/scheduler_service.py
@@ -205,10 +205,9 @@ class SchedulerService:
     async def _run_pre_generate(self, schedule: Dict[str, Any], is_weekly: bool) -> None:
         """Cleanup old meal plans before generation.
 
-        Note: clear_before_generate is intentionally ignored. Successful generation
-        atomically overwrites the old menu via _save_menu(). Clearing before generation
-        risks data loss if generation fails — the user loses their existing menu with
-        nothing to replace it.
+        Note: clear_before_generate is handled post-generation via clear_others flag
+        in the saved menu data. The frontend clears all shelves when it sees this flag,
+        giving a fresh start without risking data loss if generation fails.
         """
         cleanup_days = schedule.get("cleanup_uncooked_days", 0)
         mp_type = schedule.get("meal_plan_type")
@@ -251,7 +250,10 @@ class SchedulerService:
     async def _run_profile_pipeline(self, schedule: Dict[str, Any]) -> None:
         """Generate from profile and optionally create meal plans."""
 
-        await self._generation_callback(schedule["profile"])
+        await self._generation_callback(
+            schedule["profile"],
+            clear_others=schedule.get("clear_before_generate", False),
+        )
 
         mp_type = schedule.get("meal_plan_type")
         if schedule.get("create_meal_plan") and mp_type and self._meal_plan_callback:

--- a/morsl/services/scheduler_service.py
+++ b/morsl/services/scheduler_service.py
@@ -27,7 +27,6 @@ class SchedulerService:
         self._schedules: Dict[str, Dict[str, Any]] = {}
         self._scheduler = AsyncIOScheduler(timezone=self._timezone)
         self._generation_callback: Optional[Callable[..., Any]] = None
-        self._clear_callback: Optional[Callable[[], None]] = None
         self._meal_plan_callback: Optional[Callable[..., Any]] = None
         self._weekly_generation_callback: Optional[Callable[..., Any]] = None
         self._weekly_save_callback: Optional[Callable[..., Any]] = None
@@ -36,10 +35,6 @@ class SchedulerService:
     def set_generation_callback(self, callback: Callable[..., Any]) -> None:
         """Set the async callback for triggering generation."""
         self._generation_callback = callback
-
-    def set_clear_callback(self, callback: Callable[[], None]) -> None:
-        """Set callback that clears current menu before generation."""
-        self._clear_callback = callback
 
     def set_meal_plan_callback(self, callback: Callable[..., Any]) -> None:
         """Set async callback for meal plan operations (cleanup/create)."""
@@ -208,11 +203,13 @@ class SchedulerService:
         self._save()
 
     async def _run_pre_generate(self, schedule: Dict[str, Any], is_weekly: bool) -> None:
-        """Clear menu and cleanup old meal plans before generation."""
+        """Cleanup old meal plans before generation.
 
-        if not is_weekly and schedule.get("clear_before_generate") and self._clear_callback:
-            self._clear_callback()
-
+        Note: clear_before_generate is intentionally ignored. Successful generation
+        atomically overwrites the old menu via _save_menu(). Clearing before generation
+        risks data loss if generation fails — the user loses their existing menu with
+        nothing to replace it.
+        """
         cleanup_days = schedule.get("cleanup_uncooked_days", 0)
         mp_type = schedule.get("meal_plan_type")
         if cleanup_days > 0 and mp_type and self._meal_plan_callback:

--- a/morsl/services/weekly_generation_service.py
+++ b/morsl/services/weekly_generation_service.py
@@ -196,7 +196,7 @@ class WeeklyGenerationService:
             self._status.completed_at = now()
             self._status.warnings = result.get("warnings", [])
 
-        except Exception as e:
+        except Exception as e:  # noqa: broad-except — state machine must capture any failure
             logger.warning("Weekly generation failed", exc_info=True)
             self._status.state = GenerationState.ERROR
             self._status.completed_at = now()
@@ -299,11 +299,8 @@ class WeeklyGenerationService:
         # Get global cache setting
         cache_minutes = API_CACHE_TTL_MINUTES
         if settings_service:
-            try:
-                app_settings = settings_service.get_all()
-                cache_minutes = app_settings.get("api_cache_minutes", API_CACHE_TTL_MINUTES)
-            except Exception:  # noqa: S110
-                pass
+            app_settings = settings_service.get_all()
+            cache_minutes = app_settings.get("api_cache_minutes", API_CACHE_TTL_MINUTES)
 
         # 3. Run each profile sequentially for dedup
         all_warnings: List[str] = []
@@ -399,11 +396,8 @@ class WeeklyGenerationService:
         # Get global cache setting
         cache_minutes = API_CACHE_TTL_MINUTES
         if settings_service:
-            try:
-                app_settings = settings_service.get_all()
-                cache_minutes = app_settings.get("api_cache_minutes", API_CACHE_TTL_MINUTES)
-            except Exception:  # noqa: S110
-                pass
+            app_settings = settings_service.get_all()
+            cache_minutes = app_settings.get("api_cache_minutes", API_CACHE_TTL_MINUTES)
 
         loop = asyncio.get_running_loop()
         new_recipes = await loop.run_in_executor(

--- a/morsl/utils.py
+++ b/morsl/utils.py
@@ -46,7 +46,7 @@ def atomic_write_json(path: str, data: Any) -> None:
         with os.fdopen(fd, "w") as f:
             json.dump(data, f, indent=2)
         os.replace(tmp_path, path)
-    except Exception:
+    except (OSError, TypeError, ValueError):
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)
         raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ ignore = [
 ]
 fixable = ["ALL"]
 
+external = ["broad-except", "direct-service"]  # custom architectural lint markers
+
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["ANN", "S"]
 "morsl/app/api/routes/*.py" = ["B008"]  # FastAPI Depends() in defaults

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -226,6 +226,166 @@ class TestProfileEndpoints:
         assert data[0]["name"] == "default"
         assert data[1]["name"] == "weekend"
 
+    async def test_get_profile(self, client, mock_config_service):
+        mock_config_service.get_profile_raw.return_value = {
+            "choices": 5,
+            "constraints": [],
+        }
+        response = await client.get("/api/profiles/default")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "default"
+        assert "config" in data
+
+    async def test_get_profile_not_found(self, client, mock_config_service):
+        mock_config_service.get_profile_raw.side_effect = FileNotFoundError("not found")
+        response = await client.get("/api/profiles/missing")
+        assert response.status_code == 404
+
+    async def test_create_profile_requires_admin(self, settings_client, mock_settings_service):
+        mock_settings_service.get_all.return_value = {
+            "admin_pin_enabled": True,
+            "pin": "1234",
+            "kiosk_enabled": False,
+            "kiosk_pin_enabled": False,
+        }
+        response = await settings_client.post(
+            "/api/profiles",
+            json={"name": "new-profile", "choices": 3},
+        )
+        assert response.status_code == 401
+
+    async def test_create_profile(
+        self,
+        settings_client,
+        mock_config_service,
+        mock_settings_service,
+    ):
+        mock_settings_service.get_all.return_value = {"admin_pin_enabled": False}
+        mock_config_service.create_profile.return_value = {
+            "choices": 3,
+            "constraints": [],
+        }
+        response = await settings_client.post(
+            "/api/profiles",
+            json={"name": "new-profile", "choices": 3},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "new-profile"
+        mock_config_service.create_profile.assert_called_once()
+
+    async def test_create_profile_duplicate(
+        self,
+        settings_client,
+        mock_config_service,
+        mock_settings_service,
+    ):
+        mock_settings_service.get_all.return_value = {"admin_pin_enabled": False}
+        mock_config_service.create_profile.side_effect = FileExistsError(
+            "already exists",
+        )
+        response = await settings_client.post(
+            "/api/profiles",
+            json={"name": "existing", "choices": 3},
+        )
+        assert response.status_code == 409
+
+    async def test_update_profile(
+        self,
+        settings_client,
+        mock_config_service,
+        mock_settings_service,
+    ):
+        mock_settings_service.get_all.return_value = {"admin_pin_enabled": False}
+        mock_config_service.update_profile.return_value = {
+            "choices": 7,
+            "constraints": [],
+        }
+        response = await settings_client.put(
+            "/api/profiles/default",
+            json={"name": "default", "choices": 7},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "default"
+        mock_config_service.update_profile.assert_called_once()
+
+    async def test_update_profile_not_found(
+        self,
+        settings_client,
+        mock_config_service,
+        mock_settings_service,
+    ):
+        mock_settings_service.get_all.return_value = {"admin_pin_enabled": False}
+        mock_config_service.update_profile.side_effect = FileNotFoundError(
+            "not found",
+        )
+        response = await settings_client.put(
+            "/api/profiles/missing",
+            json={"name": "missing", "choices": 3},
+        )
+        assert response.status_code == 404
+
+    async def test_set_profile_category(
+        self,
+        settings_client,
+        mock_config_service,
+        mock_settings_service,
+    ):
+        mock_settings_service.get_all.return_value = {"admin_pin_enabled": False}
+        mock_config_service.get_profile_raw.return_value = {
+            "choices": 5,
+            "constraints": [],
+        }
+        response = await settings_client.patch(
+            "/api/profiles/default/category",
+            json={"category": "cocktails"},
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "ok"
+        mock_config_service.update_profile.assert_called_once()
+
+    async def test_set_category_not_found(
+        self,
+        settings_client,
+        mock_config_service,
+        mock_settings_service,
+    ):
+        mock_settings_service.get_all.return_value = {"admin_pin_enabled": False}
+        mock_config_service.get_profile_raw.side_effect = FileNotFoundError(
+            "not found",
+        )
+        response = await settings_client.patch(
+            "/api/profiles/missing/category",
+            json={"category": "food"},
+        )
+        assert response.status_code == 404
+
+    async def test_delete_profile(
+        self,
+        settings_client,
+        mock_config_service,
+        mock_settings_service,
+    ):
+        mock_settings_service.get_all.return_value = {"admin_pin_enabled": False}
+        response = await settings_client.delete("/api/profiles/default")
+        assert response.status_code == 204
+        mock_config_service.delete_profile.assert_called_once_with("default")
+
+    async def test_delete_profile_not_found(
+        self,
+        settings_client,
+        mock_config_service,
+        mock_settings_service,
+    ):
+        mock_settings_service.get_all.return_value = {"admin_pin_enabled": False}
+        mock_config_service.delete_profile.side_effect = FileNotFoundError(
+            "not found",
+        )
+        response = await settings_client.delete("/api/profiles/missing")
+        assert response.status_code == 404
+
 
 @pytest.mark.asyncio
 class TestSettingsEnforcement:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -194,6 +194,11 @@ class TestMenuEndpoints:
         assert len(data["recipes"]) == 1
         assert "version" in data
 
+    async def test_delete_menu(self, settings_client, mock_gen_service):
+        response = await settings_client.delete("/api/menu")
+        assert response.status_code == 204
+        mock_gen_service.clear_menu.assert_called_once()
+
     async def test_status_idle(self, client, mock_gen_service):
         response = await client.get("/api/status")
         assert response.status_code == 200

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -317,6 +317,83 @@ class TestSyncCoreModules:
         assert not violations, "asyncio imported in sync core module:\n" + "\n".join(violations)
 
 
+class TestNoBroadExcept:
+    """Broad except clauses must be explicitly grandfathered.
+
+    New modules should catch specific exceptions. Existing usage is
+    grandfathered where justified (state machines, startup/shutdown,
+    HTTP error handlers).
+    """
+
+    def test_no_broad_except(self):
+        violations = []
+        for path in _all_source_files():
+            for i, line in enumerate(path.read_text().splitlines(), 1):
+                stripped = line.strip()
+                if stripped.startswith("except Exception") and "broad-except" not in line:
+                    violations.append(f"{path.name}:{i}: {stripped}")
+        assert not violations, (
+            "Broad except clause in non-grandfathered module "
+            "(use a specific exception or add # noqa: broad-except):\n" + "\n".join(violations)
+        )
+
+
+class TestNoFrameworkImportsInServices:
+    """Services must not import FastAPI or Starlette.
+
+    Services should be framework-independent for testability.
+    All web framework types come via dependency injection.
+    """
+
+    _FRAMEWORK_MODULES = {"fastapi", "starlette"}
+
+    def test_no_framework_imports(self):
+        violations = []
+        for path in _python_files(SERVICES):
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if alias.name.split(".")[0] in self._FRAMEWORK_MODULES:
+                            violations.append(f"{path.name}:{node.lineno}: import {alias.name}")
+                elif (
+                    isinstance(node, ast.ImportFrom)
+                    and node.module
+                    and node.module.split(".")[0] in self._FRAMEWORK_MODULES
+                ):
+                    violations.append(f"{path.name}:{node.lineno}: from {node.module}")
+        assert not violations, (
+            "Framework import in service module (services must be framework-independent):\n"
+            + "\n".join(violations)
+        )
+
+
+class TestNoDirectServiceInstantiation:
+    """Route modules get services via DI, not direct construction.
+
+    Service instantiation belongs in dependencies.py. Route modules
+    should receive services as injected parameters.
+    """
+
+    _SERVICE_PATTERN = re.compile(r"\b\w+Service\(")
+    _SKIP_FILES = {"dependencies.py"}
+
+    def test_no_service_constructors_in_routes(self):
+        violations = []
+        for path in _python_files(ROUTES):
+            if path.name in self._SKIP_FILES:
+                continue
+            for i, line in enumerate(path.read_text().splitlines(), 1):
+                if "# noqa: direct-service" in line:
+                    continue
+                for match in self._SERVICE_PATTERN.finditer(line):
+                    violations.append(f"{path.name}:{i}: {match.group()}")
+        assert not violations, (
+            "Direct service instantiation in route module "
+            "(use dependency injection via dependencies.py):\n" + "\n".join(violations)
+        )
+
+
 class TestNoDirectFileWritesInRoutes:
     """Route modules don't call open() for writes."""
 

--- a/tests/test_generation_sse.py
+++ b/tests/test_generation_sse.py
@@ -1,0 +1,149 @@
+"""Tests for GenerationService SSE pub/sub and clear_others flow."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from morsl.services.generation_service import GenerationService
+
+
+class TestSubscribePubSub:
+    """subscribe / unsubscribe / _notify_subscribers mechanics."""
+
+    def test_subscribe_returns_queue(self, tmp_path):
+        svc = GenerationService(data_dir=str(tmp_path))
+        q = svc.subscribe()
+        assert isinstance(q, asyncio.Queue)
+        assert q.maxsize == 64
+
+    def test_subscribe_adds_to_list(self, tmp_path):
+        svc = GenerationService(data_dir=str(tmp_path))
+        q = svc.subscribe()
+        assert q in svc._subscribers
+
+    def test_unsubscribe_removes_queue(self, tmp_path):
+        svc = GenerationService(data_dir=str(tmp_path))
+        q = svc.subscribe()
+        svc.unsubscribe(q)
+        assert q not in svc._subscribers
+
+    def test_unsubscribe_unknown_queue_no_error(self, tmp_path):
+        svc = GenerationService(data_dir=str(tmp_path))
+        q = asyncio.Queue()
+        svc.unsubscribe(q)  # should not raise
+
+    def test_notify_delivers_to_all_subscribers(self, tmp_path):
+        svc = GenerationService(data_dir=str(tmp_path))
+        q1 = svc.subscribe()
+        q2 = svc.subscribe()
+        event = {"type": "test_event"}
+        svc._notify_subscribers(event)
+        assert q1.get_nowait() == event
+        assert q2.get_nowait() == event
+
+    def test_notify_skips_full_queues(self, tmp_path):
+        svc = GenerationService(data_dir=str(tmp_path))
+        q = svc.subscribe()
+        # Fill the queue to capacity
+        for i in range(64):
+            q.put_nowait({"type": "filler", "n": i})
+        # This should not raise — full queue is silently skipped
+        svc._notify_subscribers({"type": "overflow"})
+        assert q.qsize() == 64  # still full, overflow was dropped
+
+    def test_notify_with_no_subscribers(self, tmp_path):
+        svc = GenerationService(data_dir=str(tmp_path))
+        svc._notify_subscribers({"type": "lonely"})  # should not raise
+
+
+class TestEventEmission:
+    """Verify correct events are emitted on state transitions."""
+
+    def test_clear_menu_emits_menu_cleared(self, tmp_path):
+        menu = {"recipes": [{"id": 1, "name": "X"}]}
+        (tmp_path / "current_menu.json").write_text(json.dumps(menu))
+        svc = GenerationService(data_dir=str(tmp_path))
+
+        q = svc.subscribe()
+        svc.clear_menu()
+
+        event = q.get_nowait()
+        assert event["type"] == "menu_cleared"
+
+    def test_clear_menu_no_event_when_nothing_to_clear(self, tmp_path):
+        svc = GenerationService(data_dir=str(tmp_path))
+        q = svc.subscribe()
+        svc.clear_menu()
+        assert q.empty()
+
+    def test_save_menu_emits_menu_updated(self, tmp_path):
+        svc = GenerationService(data_dir=str(tmp_path))
+        q = svc.subscribe()
+        svc._save_menu({"recipes": [], "generated_at": "2024-01-01"})
+
+        event = q.get_nowait()
+        assert event["type"] == "menu_updated"
+        assert event["clear_others"] is False
+
+    def test_save_menu_with_clear_others(self, tmp_path):
+        svc = GenerationService(data_dir=str(tmp_path))
+        q = svc.subscribe()
+        svc._save_menu(
+            {"recipes": [], "generated_at": "2024-01-01"},
+            clear_others=True,
+        )
+
+        event = q.get_nowait()
+        assert event["type"] == "menu_updated"
+        assert event["clear_others"] is True
+
+    def test_clear_others_not_persisted_in_json(self, tmp_path):
+        """clear_others must NOT be in the saved JSON — it's SSE-only."""
+        svc = GenerationService(data_dir=str(tmp_path))
+        svc._save_menu(
+            {"recipes": [], "generated_at": "2024-01-01"},
+            clear_others=True,
+        )
+        saved = json.loads((tmp_path / "current_menu.json").read_text())
+        assert "clear_others" not in saved
+
+    @pytest.mark.asyncio
+    async def test_start_generation_emits_generating(self, tmp_path, mock_logger):
+        svc = GenerationService(data_dir=str(tmp_path))
+        q = svc.subscribe()
+
+        from unittest.mock import patch
+
+        with patch.object(
+            svc,
+            "_sync_generate",
+            return_value={
+                "recipes": [{"id": 1, "name": "T", "description": "", "rating": 3.0}],
+                "generated_at": "2024-01-01",
+                "requested_count": 1,
+                "constraint_count": 0,
+                "status": "optimal",
+                "warnings": [],
+                "relaxed_constraints": [],
+            },
+        ):
+            await svc.start_generation(
+                config={"choices": 1, "cache": 0},
+                url="http://localhost",
+                token="test",
+                logger=mock_logger,
+            )
+            if svc._current_task:
+                await svc._current_task
+
+        # Should have received: generating, then menu_updated
+        events = []
+        while not q.empty():
+            events.append(q.get_nowait())
+        types = [e["type"] for e in events]
+        assert "generating" in types
+        assert "menu_updated" in types
+        assert types.index("generating") < types.index("menu_updated")

--- a/tests/test_menu_stream.py
+++ b/tests/test_menu_stream.py
@@ -1,0 +1,122 @@
+"""Tests for the /api/menu/stream SSE endpoint.
+
+Pub/sub delivery is tested in test_generation_sse.py (same-thread, fast).
+These tests verify the HTTP endpoint wiring: content-type, subscriber lifecycle,
+and event formatting through the SSE generator.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from morsl.services.generation_service import GenerationService
+
+
+@pytest.fixture
+def gen_service(tmp_path):
+    return GenerationService(data_dir=str(tmp_path))
+
+
+class TestMenuStreamEventGenerator:
+    """Test the SSE event generator directly — no HTTP layer, no cross-thread issues."""
+
+    @pytest.mark.asyncio
+    async def test_yields_connected_event_first(self, gen_service):
+        """First yielded chunk is the connected event."""
+        from morsl.app.api.routes.menu import menu_stream
+
+        # Build a mock request to get the StreamingResponse
+        mock_service = gen_service
+        response = await menu_stream(gen_service=mock_service)
+
+        assert response.media_type == "text/event-stream"
+        assert response.headers.get("Cache-Control") == "no-cache"
+
+        # Iterate the body generator
+        body_gen = response.body_iterator
+        first_chunk = await body_gen.__anext__()
+        assert "event: connected" in first_chunk
+        assert "data: {}" in first_chunk
+
+        # Cleanup — cancel the generator
+        await body_gen.aclose()
+
+    @pytest.mark.asyncio
+    async def test_delivers_event_from_queue(self, gen_service):
+        """Events pushed to the subscriber queue appear in the SSE stream."""
+        from morsl.app.api.routes.menu import menu_stream
+
+        response = await menu_stream(gen_service=gen_service)
+        body_gen = response.body_iterator
+
+        # Consume connected event
+        await body_gen.__anext__()
+
+        # Push an event — since we're in the same event loop, put_nowait works
+        gen_service._notify_subscribers({"type": "menu_updated", "clear_others": False})
+
+        # Next chunk should be the menu_updated event
+        chunk = await body_gen.__anext__()
+        assert "event: menu_updated" in chunk
+        assert "clear_others" in chunk
+
+        await body_gen.aclose()
+
+    @pytest.mark.asyncio
+    async def test_keepalive_on_timeout(self, gen_service):
+        """When queue is empty and timeout expires, yields keepalive comment."""
+        from morsl.app.api.routes.menu import menu_stream
+
+        with patch("morsl.app.api.routes.menu.SSE_QUEUE_TIMEOUT", 0.05):
+            response = await menu_stream(gen_service=gen_service)
+            body_gen = response.body_iterator
+
+            # Consume connected event
+            await body_gen.__anext__()
+
+            # Wait for keepalive (timeout is 0.05s)
+            chunk = await body_gen.__anext__()
+            assert chunk == ": keepalive\n\n"
+
+            await body_gen.aclose()
+
+    @pytest.mark.asyncio
+    async def test_unsubscribes_on_close(self, gen_service):
+        """Closing the generator removes the subscriber queue."""
+        from morsl.app.api.routes.menu import menu_stream
+
+        response = await menu_stream(gen_service=gen_service)
+        body_gen = response.body_iterator
+
+        # After calling menu_stream, a subscriber should exist
+        assert len(gen_service._subscribers) == 1
+
+        await body_gen.__anext__()  # consume connected
+        await body_gen.aclose()
+
+        # After close, subscriber should be removed
+        assert len(gen_service._subscribers) == 0
+
+    @pytest.mark.asyncio
+    async def test_formats_event_as_sse(self, gen_service):
+        """Events are formatted with SSE event: and data: lines."""
+        from morsl.app.api.routes.menu import menu_stream
+
+        response = await menu_stream(gen_service=gen_service)
+        body_gen = response.body_iterator
+        await body_gen.__anext__()  # connected
+
+        gen_service._notify_subscribers({"type": "menu_cleared"})
+        chunk = await body_gen.__anext__()
+
+        # Verify SSE format: event line, data line, blank line
+        lines = chunk.strip().split("\n")
+        assert lines[0] == "event: menu_cleared"
+        assert lines[1].startswith("data: ")
+        data = json.loads(lines[1][len("data: ") :])
+        assert data["type"] == "menu_cleared"
+
+        await body_gen.aclose()

--- a/tests/test_recipe_detail_service.py
+++ b/tests/test_recipe_detail_service.py
@@ -1,0 +1,173 @@
+"""Tests for recipe detail fetching and ingredient extraction."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from morsl.services.recipe_detail_service import (
+    _extract_steps_and_ingredients,
+    _resolve_food,
+    fetch_recipe_details,
+)
+
+
+@pytest.fixture
+def mock_api():
+    api = MagicMock()
+    api.url = "http://localhost/api/"
+    return api
+
+
+def _make_recipe_obj(id=1, name="Test"):
+    r = MagicMock()
+    r.id = id
+    r.name = name
+    r.description = "Desc"
+    r.rating = 4.0
+    r.keywords = [10]
+    r.keyword_names = {10: "Italian"}
+    return r
+
+
+class TestResolveFood:
+    def test_returns_food_when_already_onhand(self, mock_api, mock_logger):
+        food = {"id": 1, "name": "Lime", "food_onhand": True}
+        result = _resolve_food(mock_api, food, mock_logger)
+        assert result["name"] == "Lime"
+        mock_api.get_food_substitutes.assert_not_called()
+
+    def test_substitutes_when_available(self, mock_api, mock_logger):
+        food = {"id": 1, "name": "Lime", "food_onhand": False}
+        mock_api.get_food_substitutes.return_value = [{"id": 2}]
+        mock_api.get_food.return_value = {"id": 2, "name": "Lemon"}
+
+        result = _resolve_food(mock_api, food, mock_logger)
+        assert result["name"] == "Lemon"
+
+    def test_keeps_original_when_no_subs(self, mock_api, mock_logger):
+        food = {"id": 1, "name": "Lime", "food_onhand": False}
+        mock_api.get_food_substitutes.return_value = []
+
+        result = _resolve_food(mock_api, food, mock_logger)
+        assert result["name"] == "Lime"
+
+    def test_keeps_original_on_api_error(self, mock_api, mock_logger):
+        food = {"id": 1, "name": "Lime", "food_onhand": False}
+        mock_api.get_food_substitutes.side_effect = OSError("timeout")
+
+        result = _resolve_food(mock_api, food, mock_logger)
+        assert result["name"] == "Lime"
+
+
+class TestExtractStepsAndIngredients:
+    def test_extracts_ingredients_and_steps(self, mock_api, mock_logger):
+        details = {
+            "steps": [
+                {
+                    "ingredients": [
+                        {
+                            "food": {"id": 1, "name": "Flour", "food_onhand": True},
+                            "amount": 2.0,
+                            "unit": {"name": "cups"},
+                        }
+                    ],
+                    "instruction": "Mix the flour.",
+                    "name": "Step 1",
+                    "time": 5,
+                    "order": 0,
+                }
+            ]
+        }
+
+        ingredients, steps = _extract_steps_and_ingredients(mock_api, details, mock_logger)
+        assert len(ingredients) == 1
+        assert ingredients[0]["food"] == "Flour"
+        assert ingredients[0]["amount"] == 2.0
+        assert ingredients[0]["unit"] == "cups"
+        assert len(steps) == 1
+        assert steps[0]["instruction"] == "Mix the flour."
+
+    def test_skips_ingredients_without_food_name(self, mock_api, mock_logger):
+        details = {
+            "steps": [
+                {
+                    "ingredients": [
+                        {"food": None, "amount": 1.0},
+                        {"food": {"id": 1}, "amount": 1.0},  # no name
+                    ],
+                    "instruction": "Do something.",
+                }
+            ]
+        }
+        ingredients, _steps = _extract_steps_and_ingredients(
+            mock_api,
+            details,
+            mock_logger,
+        )
+        assert len(ingredients) == 0
+
+    def test_skips_empty_instructions(self, mock_api, mock_logger):
+        details = {
+            "steps": [
+                {"ingredients": [], "instruction": ""},
+                {"ingredients": [], "instruction": "   "},
+            ]
+        }
+        _ingredients, steps = _extract_steps_and_ingredients(
+            mock_api,
+            details,
+            mock_logger,
+        )
+        assert len(steps) == 0
+
+    def test_handles_no_unit(self, mock_api, mock_logger):
+        details = {
+            "steps": [
+                {
+                    "ingredients": [
+                        {
+                            "food": {"id": 1, "name": "Salt", "food_onhand": True},
+                            "amount": 1.0,
+                            "unit": None,
+                        }
+                    ],
+                    "instruction": "Add salt.",
+                }
+            ]
+        }
+        ingredients, _ = _extract_steps_and_ingredients(mock_api, details, mock_logger)
+        assert ingredients[0]["unit"] is None
+
+
+class TestFetchRecipeDetails:
+    def test_fetches_details_for_each_recipe(self, mock_api, mock_logger):
+        r1 = _make_recipe_obj(1, "Pasta")
+        r2 = _make_recipe_obj(2, "Pizza")
+
+        mock_api.get_recipe_details.return_value = {
+            "image": "http://img.jpg",
+            "working_time": 10,
+            "cooking_time": 20,
+            "keywords": [{"id": 10, "name": "Italian"}],
+            "steps": [],
+        }
+
+        results = fetch_recipe_details(mock_api, [r1, r2], mock_logger)
+        assert len(results) == 2
+        assert results[0]["name"] == "Pasta"
+        assert results[0]["image"] == "http://img.jpg"
+        assert results[1]["name"] == "Pizza"
+
+    def test_handles_api_error_gracefully(self, mock_api, mock_logger):
+        from morsl.tandoor_api import TandoorError
+
+        r1 = _make_recipe_obj(1, "Broken")
+        mock_api.get_recipe_details.side_effect = TandoorError("fail")
+
+        results = fetch_recipe_details(mock_api, [r1], mock_logger)
+        assert len(results) == 1
+        assert results[0]["name"] == "Broken"
+        assert results[0]["image"] is None  # fallback
+        assert results[0]["ingredients"] == []

--- a/tests/test_scheduler_service.py
+++ b/tests/test_scheduler_service.py
@@ -128,11 +128,12 @@ class TestSchedulerService:
         svc.stop()
 
     @pytest.mark.asyncio
-    async def test_clear_before_generate_ignored(self, tmp_path):
-        """clear_before_generate should NOT clear the menu before generation.
+    async def test_clear_before_generate_passes_flag(self, tmp_path):
+        """clear_before_generate passes clear_others=True to the generation callback.
 
-        Clearing before generation risks data loss if generation fails — the user
-        loses their existing menu. Success already overwrites atomically.
+        The menu is not cleared before generation (avoids data loss on failure).
+        Instead, the flag is forwarded so the generated menu includes clear_others,
+        telling the frontend to wipe stale shelves after successful generation.
         """
         svc = SchedulerService(data_dir=str(tmp_path))
         gen_mock = AsyncMock()
@@ -143,6 +144,135 @@ class TestSchedulerService:
         )
         await svc._run_scheduled_generation(schedule["id"])
 
+        gen_mock.assert_called_once_with("gin", clear_others=True)
+
+    @pytest.mark.asyncio
+    async def test_clear_before_generate_false_omits_flag(self, tmp_path):
+        """When clear_before_generate is false, clear_others=False is passed."""
+        svc = SchedulerService(data_dir=str(tmp_path))
+        gen_mock = AsyncMock()
+        svc.set_generation_callback(gen_mock)
+
+        schedule = svc.create_schedule(
+            {"profile": "gin", "clear_before_generate": False, "enabled": True}
+        )
+        await svc._run_scheduled_generation(schedule["id"])
+
+        gen_mock.assert_called_once_with("gin", clear_others=False)
+
+    @pytest.mark.asyncio
+    async def test_profile_pipeline_creates_meal_plan(self, tmp_path):
+        """When create_meal_plan is set, meal plan callback fires after generation."""
+        svc = SchedulerService(data_dir=str(tmp_path))
+        gen_mock = AsyncMock()
+        mp_mock = AsyncMock()
+        svc.set_generation_callback(gen_mock)
+        svc.set_meal_plan_callback(mp_mock)
+
+        schedule = svc.create_schedule(
+            {
+                "profile": "gin",
+                "create_meal_plan": True,
+                "meal_plan_type": 3,
+                "enabled": True,
+            }
+        )
+        await svc._run_scheduled_generation(schedule["id"])
+
         gen_mock.assert_called_once()
-        # clear_callback was removed from SchedulerService entirely
-        assert not hasattr(svc, "_clear_callback")
+        mp_mock.assert_called_once_with("create", {"meal_plan_type": 3})
+
+    @pytest.mark.asyncio
+    async def test_profile_pipeline_skips_meal_plan_when_disabled(self, tmp_path):
+        svc = SchedulerService(data_dir=str(tmp_path))
+        gen_mock = AsyncMock()
+        mp_mock = AsyncMock()
+        svc.set_generation_callback(gen_mock)
+        svc.set_meal_plan_callback(mp_mock)
+
+        schedule = svc.create_schedule(
+            {"profile": "gin", "create_meal_plan": False, "enabled": True}
+        )
+        await svc._run_scheduled_generation(schedule["id"])
+
+        gen_mock.assert_called_once()
+        mp_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pre_generate_cleanup(self, tmp_path):
+        """cleanup_uncooked_days triggers meal plan cleanup before generation."""
+        svc = SchedulerService(data_dir=str(tmp_path))
+        gen_mock = AsyncMock()
+        mp_mock = AsyncMock()
+        svc.set_generation_callback(gen_mock)
+        svc.set_meal_plan_callback(mp_mock)
+
+        schedule = svc.create_schedule(
+            {
+                "profile": "gin",
+                "cleanup_uncooked_days": 7,
+                "meal_plan_type": 3,
+                "enabled": True,
+            }
+        )
+        await svc._run_scheduled_generation(schedule["id"])
+
+        # Cleanup call should happen before generation
+        assert mp_mock.call_count == 1
+        mp_mock.assert_called_once_with("cleanup", {"meal_plan_type": 3, "cleanup_days": 7})
+
+    @pytest.mark.asyncio
+    async def test_weekly_pipeline_calls_weekly_callback(self, tmp_path):
+        svc = SchedulerService(data_dir=str(tmp_path))
+        weekly_mock = AsyncMock()
+        svc.set_weekly_generation_callback(weekly_mock)
+
+        schedule = svc.create_schedule({"template": "weeknight", "enabled": True})
+        await svc._run_scheduled_generation(schedule["id"])
+
+        weekly_mock.assert_called_once()
+        call_args = weekly_mock.call_args
+        assert call_args[0][0] == "weeknight"
+
+    @pytest.mark.asyncio
+    async def test_scheduled_generation_updates_last_run(self, tmp_path):
+        svc = SchedulerService(data_dir=str(tmp_path))
+        gen_mock = AsyncMock()
+        svc.set_generation_callback(gen_mock)
+
+        schedule = svc.create_schedule({"profile": "gin", "enabled": True})
+        assert schedule["last_run"] is None
+
+        await svc._run_scheduled_generation(schedule["id"])
+
+        updated = svc._schedules[schedule["id"]]
+        assert updated["last_run"] is not None
+
+    @pytest.mark.asyncio
+    async def test_missing_schedule_id_returns_early(self, tmp_path):
+        svc = SchedulerService(data_dir=str(tmp_path))
+        gen_mock = AsyncMock()
+        svc.set_generation_callback(gen_mock)
+        await svc._run_scheduled_generation("nonexistent-id")
+        gen_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_callback_returns_early(self, tmp_path):
+        svc = SchedulerService(data_dir=str(tmp_path))
+        # No callback set
+        schedule = svc.create_schedule({"profile": "gin", "enabled": True})
+        await svc._run_scheduled_generation(schedule["id"])
+        # Should complete without error
+
+    def test_create_requires_profile_or_template(self, scheduler_service):
+        with pytest.raises(ValueError, match="Either"):
+            scheduler_service.create_schedule({})
+
+    def test_create_rejects_both_profile_and_template(self, scheduler_service):
+        with pytest.raises(ValueError, match="Cannot set both"):
+            scheduler_service.create_schedule({"profile": "gin", "template": "weeknight"})
+
+    def test_update_rejects_both_profile_and_template(self, scheduler_service):
+        s = scheduler_service.create_schedule({"profile": "gin"})
+        with pytest.raises(ValueError, match="Cannot set both"):
+            scheduler_service.update_schedule(s["id"], {"template": "weeknight"})

--- a/tests/test_scheduler_service.py
+++ b/tests/test_scheduler_service.py
@@ -126,3 +126,23 @@ class TestSchedulerService:
         jobs = svc._scheduler.get_jobs()
         assert len(jobs) == 1
         svc.stop()
+
+    @pytest.mark.asyncio
+    async def test_clear_before_generate_ignored(self, tmp_path):
+        """clear_before_generate should NOT clear the menu before generation.
+
+        Clearing before generation risks data loss if generation fails — the user
+        loses their existing menu. Success already overwrites atomically.
+        """
+        svc = SchedulerService(data_dir=str(tmp_path))
+        gen_mock = AsyncMock()
+        svc.set_generation_callback(gen_mock)
+
+        schedule = svc.create_schedule(
+            {"profile": "gin", "clear_before_generate": True, "enabled": True}
+        )
+        await svc._run_scheduled_generation(schedule["id"])
+
+        gen_mock.assert_called_once()
+        # clear_callback was removed from SchedulerService entirely
+        assert not hasattr(svc, "_clear_callback")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -540,3 +540,19 @@ class TestGenerationService:
                 loop.run_until_complete(self._async_start(svc, {}, mock_logger))
             finally:
                 loop.close()
+
+    def test_clear_menu(self, tmp_path):
+        menu_data = {"recipes": [{"id": 1, "name": "Test"}]}
+        (tmp_path / "current_menu.json").write_text(json.dumps(menu_data))
+        svc = GenerationService(data_dir=str(tmp_path))
+        assert svc.get_current_menu() is not None
+
+        result = svc.clear_menu()
+        assert result is True
+        assert svc.get_current_menu() is None
+        assert not (tmp_path / "current_menu.json").exists()
+
+    def test_clear_menu_nothing_to_clear(self, tmp_path):
+        svc = GenerationService(data_dir=str(tmp_path))
+        result = svc.clear_menu()
+        assert result is False

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1205,3 +1205,71 @@ class TestGenerationService:
         svc = GenerationService(data_dir=str(tmp_path))
         result = svc.clear_menu()
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_no_task(self, tmp_path):
+        """wait_for_completion returns current status when no task is running."""
+        svc = GenerationService(data_dir=str(tmp_path))
+        status = await svc.wait_for_completion()
+        assert status.state == GenerationState.IDLE
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_waits_for_task(self, tmp_path, mock_logger):
+        """wait_for_completion blocks until the generation task completes."""
+        svc = GenerationService(data_dir=str(tmp_path))
+        with patch.object(
+            svc,
+            "_sync_generate",
+            return_value={
+                "recipes": [{"id": 1, "name": "Test"}],
+                "generated_at": "2024-01-01T00:00:00",
+                "requested_count": 1,
+                "constraint_count": 0,
+                "status": "optimal",
+                "warnings": [],
+                "relaxed_constraints": [],
+            },
+        ):
+            await svc.start_generation(
+                config={"choices": 1, "cache": 0},
+                url="http://localhost",
+                token="test",
+                logger=mock_logger,
+            )
+            status = await svc.wait_for_completion(timeout=5.0)
+        assert status.state == GenerationState.COMPLETE
+
+    @pytest.mark.asyncio
+    async def test_shutdown_when_idle(self, tmp_path):
+        """shutdown does nothing when no task is running."""
+        svc = GenerationService(data_dir=str(tmp_path))
+        await svc.shutdown()
+        assert svc.get_status().state == GenerationState.IDLE
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_running_task(self, tmp_path, mock_logger):
+        """shutdown cancels an in-flight generation and resets state to IDLE."""
+        svc = GenerationService(data_dir=str(tmp_path))
+
+        # Use a slow sync_generate to ensure the task is still running
+        async def slow_generate(*args, **kwargs):
+            await asyncio.sleep(10)
+
+        with patch.object(svc, "_run_generation", side_effect=slow_generate):
+            await svc.start_generation(
+                config={"choices": 1, "cache": 0},
+                url="http://localhost",
+                token="test",
+                logger=mock_logger,
+            )
+            assert svc.get_status().state == GenerationState.GENERATING
+            await svc.shutdown(timeout=2.0)
+        assert svc.get_status().state == GenerationState.IDLE
+
+    def test_cleanup_stale_temp_files(self, tmp_path):
+        """Stale .tmp files are removed on init."""
+        (tmp_path / "menu.tmp").write_text("stale")
+        (tmp_path / "current_menu.json").write_text('{"recipes": []}')
+        GenerationService(data_dir=str(tmp_path))
+        assert not (tmp_path / "menu.tmp").exists()
+        assert (tmp_path / "current_menu.json").exists()

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -221,3 +221,77 @@ class TestBackwardCompatibility:
         picker.add_keyword_constraint(italian, 8, ">=")
         with pytest.raises(RuntimeError, match="No solution found"):
             picker.solve()
+
+
+class TestDateConstraints:
+    """Test add_cookedon_constraints and add_createdon_constraints."""
+
+    def test_cookedon_gte_constraint(self, sample_recipes, mock_logger):
+        """cookedon constraint with >= selects recently-cooked recipes."""
+        cooked = [r for r in sample_recipes if r.cookedon is not None]
+        picker = RecipePicker(sample_recipes, 5, logger=mock_logger)
+        picker.add_cookedon_constraints(cooked, 2, ">=")
+        result = picker.solve()
+        sel_cooked = [r for r in result.recipes if r.cookedon is not None]
+        assert len(sel_cooked) >= 2
+
+    def test_cookedon_lte_constraint(self, sample_recipes, mock_logger):
+        """cookedon constraint with <= caps cooked recipes."""
+        cooked = [r for r in sample_recipes if r.cookedon is not None]
+        picker = RecipePicker(sample_recipes, 5, logger=mock_logger)
+        # 8 of 10 recipes have been cooked; allow at most 4 in selection of 5
+        picker.add_cookedon_constraints(cooked, 4, "<=")
+        result = picker.solve()
+        sel_cooked = [r for r in result.recipes if r.cookedon is not None]
+        assert len(sel_cooked) <= 4
+
+    def test_createdon_gte_constraint(self, sample_recipes, mock_logger):
+        """createdon constraint with >= selects recipes created in date range."""
+        from datetime import datetime, timezone
+
+        cutoff = datetime(2023, 5, 1, tzinfo=timezone.utc)
+        recent = [r for r in sample_recipes if r.createdon and r.createdon >= cutoff]
+        picker = RecipePicker(sample_recipes, 5, logger=mock_logger)
+        picker.add_createdon_constraints(recent, 2, ">=")
+        result = picker.solve()
+        sel_recent = [r for r in result.recipes if r.createdon and r.createdon >= cutoff]
+        assert len(sel_recent) >= 2
+
+    def test_cookedon_exclude(self, sample_recipes, mock_logger):
+        """exclude=True inverts cooked set — constrains never-cooked recipes."""
+        cooked = [r for r in sample_recipes if r.cookedon is not None]
+        picker = RecipePicker(sample_recipes, 5, logger=mock_logger)
+        # exclude=True: constraint applies to never-cooked recipes
+        picker.add_cookedon_constraints(cooked, 1, ">=", exclude=True)
+        result = picker.solve()
+        sel_uncooked = [r for r in result.recipes if r.cookedon is None]
+        assert len(sel_uncooked) >= 1
+
+    def test_cookedon_uses_correct_label(self, sample_recipes, mock_logger):
+        """Verify the constraint label is 'cookedon'."""
+        cooked = [r for r in sample_recipes if r.cookedon is not None]
+        picker = RecipePicker(sample_recipes, 5, logger=mock_logger)
+        picker.add_cookedon_constraints(cooked, 1, ">=")
+        assert picker._constraint_specs[-1]["label"] == "cookedon"
+
+    def test_createdon_uses_correct_label(self, sample_recipes, mock_logger):
+        """Verify the constraint label is 'createdon'."""
+        picker = RecipePicker(sample_recipes, 5, logger=mock_logger)
+        picker.add_createdon_constraints(sample_recipes[:3], 1, ">=")
+        assert picker._constraint_specs[-1]["label"] == "createdon"
+
+    def test_date_constraints_no_intersect_pool(self, sample_recipes, mock_logger):
+        """Date constraints use intersect_pool=False (unlike food/book)."""
+        picker = RecipePicker(sample_recipes, 5, logger=mock_logger)
+        picker.add_cookedon_constraints(sample_recipes[:3], 1, ">=")
+        assert picker._constraint_specs[-1]["intersect_pool"] is False
+
+    def test_cookedon_soft_constraint(self, sample_recipes, mock_logger):
+        """Cookedon constraint with weight > 0 behaves as soft constraint."""
+        cooked = [r for r in sample_recipes if r.cookedon is not None]
+        picker = RecipePicker(sample_recipes, 5, logger=mock_logger)
+        # Impossible: require 10 cooked recipes in selection of 5
+        picker.add_cookedon_constraints(cooked, 10, ">=", weight=50)
+        result = picker.solve()
+        assert len(result.recipes) == 5
+        assert len(result.relaxed_constraints) > 0

--- a/tests/test_template_service.py
+++ b/tests/test_template_service.py
@@ -1,0 +1,192 @@
+"""Tests for TemplateService — CRUD, validation, expansion, generation plan."""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock
+
+import pytest
+
+from morsl.services.template_service import TemplateService
+
+
+@pytest.fixture
+def template_service(tmp_path):
+    return TemplateService(data_dir=str(tmp_path))
+
+
+def _make_template(profile="dinner", days=None, meal_type_id=1, recipes_per_day=2):
+    return {
+        "slots": [
+            {
+                "days": days or ["mon", "wed", "fri"],
+                "profile": profile,
+                "meal_type_id": meal_type_id,
+                "meal_type_name": "Dinner",
+                "recipes_per_day": recipes_per_day,
+            }
+        ],
+        "deduplicate": True,
+    }
+
+
+class TestTemplateNameValidation:
+    @pytest.mark.parametrize(
+        "name",
+        ["valid-name", "a1", "test-123", "weeknight"],
+    )
+    def test_valid_names_accepted(self, name):
+        TemplateService._validate_name(name)  # should not raise
+
+    @pytest.mark.parametrize(
+        ("name", "reason"),
+        [
+            ("", "empty"),
+            ("../etc/passwd", "path traversal"),
+            ("UPPERCASE", "uppercase"),
+            ("-leading-dash", "leading dash"),
+            ("has spaces", "spaces"),
+            ("has.dot", "dot"),
+        ],
+    )
+    def test_invalid_names_rejected(self, name, reason):
+        with pytest.raises(ValueError, match="Invalid template name"):
+            TemplateService._validate_name(name)
+
+
+class TestTemplateCRUD:
+    def test_list_empty(self, template_service):
+        assert template_service.list_templates() == []
+
+    def test_create_and_get(self, template_service):
+        tpl = _make_template()
+        created = template_service.create_template("weeknight", tpl)
+        assert created["name"] == "weeknight"
+
+        loaded = template_service.get_template("weeknight")
+        assert loaded["name"] == "weeknight"
+        assert len(loaded["slots"]) == 1
+
+    def test_create_duplicate_raises(self, template_service):
+        template_service.create_template("weeknight", _make_template())
+        with pytest.raises(FileExistsError, match="already exists"):
+            template_service.create_template("weeknight", _make_template())
+
+    def test_list_returns_summaries(self, template_service):
+        template_service.create_template("a-template", _make_template())
+        template_service.create_template("b-template", _make_template(days=["tue"]))
+        result = template_service.list_templates()
+        assert len(result) == 2
+        names = {t["name"] for t in result}
+        assert names == {"a-template", "b-template"}
+        assert all("slot_count" in t for t in result)
+
+    def test_update_template(self, template_service):
+        template_service.create_template("weeknight", _make_template())
+        updated = template_service.update_template("weeknight", _make_template(recipes_per_day=5))
+        assert updated["slots"][0]["recipes_per_day"] == 5
+
+    def test_update_nonexistent_raises(self, template_service):
+        with pytest.raises(FileNotFoundError, match="not found"):
+            template_service.update_template("nope", _make_template())
+
+    def test_delete_template(self, template_service):
+        template_service.create_template("weeknight", _make_template())
+        template_service.delete_template("weeknight")
+        assert template_service.list_templates() == []
+
+    def test_delete_nonexistent_raises(self, template_service):
+        with pytest.raises(FileNotFoundError, match="not found"):
+            template_service.delete_template("nope")
+
+    def test_get_nonexistent_raises(self, template_service):
+        with pytest.raises(FileNotFoundError, match="not found"):
+            template_service.get_template("nope")
+
+
+class TestTemplateValidation:
+    def _mock_config_service(self, profile_names):
+        cs = MagicMock()
+        profiles = [MagicMock(name=n) for n in profile_names]
+        # MagicMock overrides 'name', so set it explicitly
+        for p, n in zip(profiles, profile_names, strict=True):
+            p.name = n
+        cs.list_profiles.return_value = profiles
+        return cs
+
+    def test_valid_template_no_errors(self, template_service):
+        cs = self._mock_config_service(["dinner"])
+        errors = template_service.validate_template(_make_template(), cs)
+        assert errors == []
+
+    def test_missing_slots(self, template_service):
+        cs = self._mock_config_service([])
+        errors = template_service.validate_template({}, cs)
+        assert any("at least one slot" in e for e in errors)
+
+    def test_invalid_day(self, template_service):
+        cs = self._mock_config_service(["dinner"])
+        tpl = _make_template(days=["monday"])
+        errors = template_service.validate_template(tpl, cs)
+        assert any("invalid day" in e for e in errors)
+
+    def test_missing_profile(self, template_service):
+        cs = self._mock_config_service(["other"])
+        errors = template_service.validate_template(_make_template(), cs)
+        assert any("not found" in e for e in errors)
+
+    def test_invalid_recipes_per_day(self, template_service):
+        cs = self._mock_config_service(["dinner"])
+        tpl = _make_template(recipes_per_day=0)
+        errors = template_service.validate_template(tpl, cs)
+        assert any("recipes_per_day" in e for e in errors)
+
+
+class TestExpandSlots:
+    def test_expands_days_to_dates(self, template_service):
+        tpl = _make_template(days=["mon", "wed"])
+        # 2024-01-01 is a Monday
+        result = template_service.expand_slots(tpl, date(2024, 1, 1))
+        assert "2024-01-01" in result  # Monday
+        assert "2024-01-03" in result  # Wednesday
+        assert len(result) == 2
+
+    def test_non_monday_raises(self, template_service):
+        tpl = _make_template()
+        with pytest.raises(ValueError, match="Monday"):
+            template_service.expand_slots(tpl, date(2024, 1, 2))  # Tuesday
+
+    def test_assignment_has_correct_fields(self, template_service):
+        tpl = _make_template(days=["mon"], meal_type_id=5, recipes_per_day=3)
+        result = template_service.expand_slots(tpl, date(2024, 1, 1))
+        assignment = result["2024-01-01"][0]
+        assert assignment["meal_type_id"] == 5
+        assert assignment["recipes_per_day"] == 3
+        assert assignment["profile"] == "dinner"
+
+
+class TestGenerationPlan:
+    def test_single_profile(self, template_service):
+        tpl = _make_template(days=["mon", "wed", "fri"], recipes_per_day=2)
+        plan = template_service.get_generation_plan(tpl)
+        assert plan == {"dinner": 6}  # 3 days * 2 rpd
+
+    def test_multiple_profiles(self, template_service):
+        tpl = {
+            "slots": [
+                {
+                    "days": ["mon", "tue"],
+                    "profile": "dinner",
+                    "meal_type_id": 1,
+                    "recipes_per_day": 2,
+                },
+                {
+                    "days": ["mon", "tue", "wed"],
+                    "profile": "lunch",
+                    "meal_type_id": 2,
+                    "recipes_per_day": 1,
+                },
+            ]
+        }
+        plan = template_service.get_generation_plan(tpl)
+        assert plan == {"dinner": 4, "lunch": 3}

--- a/tests/test_weekly_generation_service.py
+++ b/tests/test_weekly_generation_service.py
@@ -1,0 +1,123 @@
+"""Tests for WeeklyGenerationService — plan CRUD, validation, state machine."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from morsl.services.generation_service import GenerationState
+from morsl.services.weekly_generation_service import (
+    WeeklyGenerationService,
+    _distribute_to_slots,
+    _validate_template_name,
+)
+
+
+@pytest.fixture
+def weekly_service(tmp_path):
+    return WeeklyGenerationService(data_dir=str(tmp_path))
+
+
+class TestTemplateNameValidation:
+    @pytest.mark.parametrize("name", ["weeknight", "a1", "test-plan"])
+    def test_valid_names(self, name):
+        _validate_template_name(name)  # no raise
+
+    @pytest.mark.parametrize("name", ["", "../escape", "UPPER", "-dash"])
+    def test_invalid_names(self, name):
+        with pytest.raises(ValueError, match="Invalid template name"):
+            _validate_template_name(name)
+
+
+class TestPlanCRUD:
+    def test_get_plan_none_when_missing(self, weekly_service):
+        assert weekly_service.get_plan("weeknight") is None
+
+    def test_save_and_get_plan(self, weekly_service):
+        plan = {"template": "weeknight", "days": {}, "warnings": []}
+        weekly_service._save_plan("weeknight", plan)
+        loaded = weekly_service.get_plan("weeknight")
+        assert loaded["template"] == "weeknight"
+
+    def test_save_creates_directory(self, weekly_service):
+        weekly_service._save_plan("weeknight", {"template": "weeknight"})
+        assert os.path.isdir(weekly_service.plans_dir)
+
+    def test_clear_plan_removes_file(self, weekly_service):
+        weekly_service._save_plan("weeknight", {"template": "weeknight"})
+        assert weekly_service.clear_plan("weeknight") is True
+        assert weekly_service.get_plan("weeknight") is None
+
+    def test_clear_plan_returns_false_when_missing(self, weekly_service):
+        assert weekly_service.clear_plan("weeknight") is False
+
+    def test_get_plan_handles_corrupt_json(self, weekly_service, tmp_path):
+        os.makedirs(weekly_service.plans_dir, exist_ok=True)
+        plan_path = os.path.join(weekly_service.plans_dir, "weeknight.json")
+        with open(plan_path, "w") as f:
+            f.write("{invalid json")
+        assert weekly_service.get_plan("weeknight") is None
+
+
+class TestWeeklyStateTransitions:
+    def test_initial_state_idle(self, weekly_service):
+        assert weekly_service.get_status().state == GenerationState.IDLE
+
+    @pytest.mark.asyncio
+    async def test_shutdown_when_idle(self, weekly_service):
+        await weekly_service.shutdown()  # should not raise
+        assert weekly_service.get_status().state == GenerationState.IDLE
+
+
+class TestDistributeToSlots:
+    def test_distributes_recipes_to_correct_days(self):
+        from morsl.models import make_recipe as _mr
+
+        _base = {
+            "keywords": [],
+            "rating": 0,
+            "new": False,
+            "servings": 4,
+            "created_at": "2024-01-01T00:00:00",
+        }
+        r1 = _mr({"id": 1, "name": "A", **_base})
+        r2 = _mr({"id": 2, "name": "B", **_base})
+
+        _slot = {
+            "meal_type_id": 1,
+            "meal_type_name": "Dinner",
+            "profile": "dinner",
+            "recipes_per_day": 1,
+        }
+        expanded = {
+            "2024-01-01": [_slot],
+            "2024-01-02": [_slot],
+        }
+        profile_recipes = {"dinner": [r1, r2]}
+        detail_map = {
+            1: {"id": 1, "name": "A", "image": None},
+            2: {"id": 2, "name": "B", "image": None},
+        }
+
+        result = _distribute_to_slots(expanded, profile_recipes, detail_map)
+        assert "2024-01-01" in result
+        assert "2024-01-02" in result
+        day1_recipes = result["2024-01-01"]["meals"]["1"]["recipes"]
+        day2_recipes = result["2024-01-02"]["meals"]["1"]["recipes"]
+        assert len(day1_recipes) == 1
+        assert len(day2_recipes) == 1
+        # Recipes are distributed in order — first to day 1, second to day 2
+        assert day1_recipes[0]["id"] == 1
+        assert day2_recipes[0]["id"] == 2
+
+    def test_empty_queue_produces_empty_recipes(self):
+        slot = {
+            "meal_type_id": 1,
+            "meal_type_name": "Dinner",
+            "profile": "dinner",
+            "recipes_per_day": 2,
+        }
+        expanded = {"2024-01-01": [slot]}
+        result = _distribute_to_slots(expanded, {}, {})
+        assert result["2024-01-01"]["meals"]["1"]["recipes"] == []

--- a/web/admin.html
+++ b/web/admin.html
@@ -211,13 +211,8 @@
                         <span class="toggle-track"></span>
                     </label>
                 </div>
-                <div class="settings-row">
-                    <div class="settings-label">Clear Local Menu<small>Start fresh — clear the current menu before generating</small></div>
-                    <label class="toggle-switch">
-                        <input type="checkbox" x-model="scheduleForm.clear_before_generate">
-                        <span class="toggle-track"></span>
-                    </label>
-                </div>
+                <!-- clear_before_generate removed: generation always overwrites atomically.
+                     Clearing before generation risks data loss if generation fails. -->
                 </div>
                 <!-- Advanced: meal plan integration -->
                 <div x-show="tierVisible('standard')">
@@ -278,17 +273,20 @@
         </section>
 
         <!-- Current Menu -->
-        <section class="admin-section" x-show="recipes.length > 0">
+        <section class="admin-section">
             <h2 class="section-title">
                 Current Menu
             </h2>
             <div style="margin-bottom: 0.75rem;">
-                <button class="btn-generate btn-secondary" @click="clearRecipes()"
+                <button class="btn-generate btn-secondary" @click="clearMenu()"
                         style="height:30px; font-size:0.85rem;">
-                    Clear All Recipes
+                    Clear Menu
                 </button>
             </div>
-            <div class="menu-grid">
+            <template x-if="recipes.length === 0">
+                <p class="text-muted" style="opacity:0.6; font-size:0.9rem;">No menu generated.</p>
+            </template>
+            <div class="menu-grid" x-show="recipes.length > 0">
                 <template x-for="recipe in recipes" :key="recipe.id">
                     <div class="menu-card" @click="openRecipe(recipe)">
                         <img class="menu-card-image" x-show="recipe.image"

--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -379,10 +379,21 @@ body {
     flex-direction: column;
 }
 
+/* ---- Menu Date ---- */
+.menu-date {
+    flex: 0 0 auto;
+    text-align: center;
+    font-family: var(--heading-font);
+    font-size: 1.1rem;
+    color: var(--accent-color);
+    padding: 0.25rem 1rem 0;
+    letter-spacing: 0.02em;
+}
+
 /* ---- Carousel ---- */
 .carousel-container {
-    flex: 0 0 auto;
-    min-height: 300px;
+    flex: 1 1 auto;
+    min-height: 150px;
 }
 
 .carousel-wrapper {

--- a/web/index.html
+++ b/web/index.html
@@ -180,11 +180,16 @@
                 <p>Create a profile to start generating menus</p>
                 <a href="/admin#profiles" class="empty-state-btn">Create Profile</a>
             </div>
-            <!-- Empty state: profiles exist but no recipes generated -->
-            <div class="empty-state" x-show="profiles.length > 0 && mainCarouselRecipes.length === 0 && shelves.length === 0 && state === 'ready'">
-                <h2>No recipes yet</h2>
+            <!-- Empty state: profiles exist and visible — tap one to generate -->
+            <div class="empty-state" x-show="visibleProfiles.length > 0 && mainCarouselRecipes.length === 0 && shelves.length === 0 && state === 'ready'">
+                <h2>No menu generated</h2>
                 <p>Tap a profile above to generate your menu</p>
-                <a href="/admin#generate" class="empty-state-btn">Generate Your First Menu</a>
+            </div>
+            <!-- Empty state: profiles exist but none visible on this page -->
+            <div class="empty-state" x-show="profiles.length > 0 && visibleProfiles.length === 0 && mainCarouselRecipes.length === 0 && shelves.length === 0 && state === 'ready'">
+                <h2>No menu available</h2>
+                <p>Generate a menu from the admin page</p>
+                <a href="/admin#generate" class="empty-state-btn">Go to Admin</a>
             </div>
 
             <!-- Carousel wrapper -->
@@ -524,7 +529,7 @@
     <!-- Error state -->
     <div class="error-state" x-show="state === 'error'">
         <p x-text="errorMessage || 'Something went wrong'"></p>
-        <button class="retry-btn" @click="loadMenu()">Try Again</button>
+        <button class="retry-btn" @click="retryGeneration()">Try Again</button>
     </div>
 
     <!-- Hamburger navigation (hidden when kiosk uses a gesture) -->

--- a/web/index.html
+++ b/web/index.html
@@ -152,6 +152,9 @@
     <div class="content-area"
          x-show="state === 'ready' || state === 'generating'">
 
+        <!-- Menu date -->
+        <div class="menu-date" x-show="generatedAt && mainCarouselRecipes.length > 0" x-text="formatMenuDate(generatedAt)"></div>
+
         <!-- Deck tab strip -->
         <div class="deck-strip" x-show="shelves.length > 1">
             <template x-for="shelf in shelves" :key="'tab-' + shelf.name">

--- a/web/js/admin.js
+++ b/web/js/admin.js
@@ -503,12 +503,12 @@ function adminApp() {
             }
         },
 
-        clearRecipes() {
+        clearMenu() {
             this.confirmModal = {
                 show: true,
-                title: 'Clear All Recipes?',
-                message: 'This will remove all recipes from the current menu. This cannot be undone.',
-                confirmText: 'Clear All',
+                title: 'Clear Menu?',
+                message: 'This will remove the current menu.',
+                confirmText: 'Clear',
                 onConfirm: async () => {
                     try {
                         const res = await this.adminFetch('/api/menu', { method: 'DELETE' });
@@ -519,7 +519,7 @@ function adminApp() {
                             this.menuMeta = {};
                         }
                     } catch (e) {
-                        this.showError('Failed to clear recipes: ' + e.message);
+                        this.showError('Failed to clear menu: ' + e.message);
                     }
                 },
             };

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -367,13 +367,13 @@ function menuApp() {
                     this.applyMenuData(await res.json());
                     this.state = 'ready';
                 } else if (res.status === 404) {
-                    // No server menu — clear stale localStorage shelves
+                    // No server menu — check if generation failed
                     this.shelves = [];
                     this.activeDeckName = null;
                     this.recipes = [];
                     this.currentRecipes = [];
                     this.saveShelves();
-                    this.state = 'ready';
+                    await this._checkGenerationStatus();
                 } else {
                     this.state = 'error';
                     this.errorMessage = 'Failed to load menu';
@@ -382,6 +382,27 @@ function menuApp() {
                 this.state = 'error';
                 this.errorMessage = 'Cannot reach server';
             }
+        },
+
+        async _checkGenerationStatus() {
+            try {
+                const res = await fetch('/api/status');
+                if (res.ok) {
+                    const status = await res.json();
+                    if (status.state === 'error') {
+                        this.state = 'error';
+                        this.errorMessage = status.error || 'Generation failed';
+                        return;
+                    } else if (status.state === 'generating') {
+                        this.state = 'generating';
+                        this.startStatusPolling();
+                        return;
+                    }
+                }
+            } catch (e) {
+                // Fall through to ready state
+            }
+            this.state = 'ready';
         },
 
         applyMenuData(data) {
@@ -501,6 +522,16 @@ function menuApp() {
             } catch (e) {
                 this.state = 'error';
                 this.errorMessage = 'Cannot reach server';
+            }
+        },
+
+        retryGeneration() {
+            if (this.activeProfile) {
+                this.switchProfile(this.activeProfile);
+            } else if (this.visibleProfiles.length > 0) {
+                this.switchProfile(this.visibleProfiles[0].name);
+            } else {
+                this.loadMenu();
             }
         },
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -58,6 +58,13 @@ function menuApp() {
         _carouselCache: null,
         _carouselCacheKey: null,
 
+        // Menu SSE
+        _menuSSE: null,
+        _sseRetryDelay: 1000,
+        _loadMenuInFlight: false,
+        _loadMenuPending: false,
+        _pendingClearOthers: false,
+
         // Category shelves (persistent per-category rows)
         shelves: [],          // [{name, generations: [{recipes, generatedAt}], currentIndex: 0}, ...]
         activeDeckName: null, // which shelf is in the main carousel
@@ -237,6 +244,7 @@ function menuApp() {
             this._iconHandler = () => this._iconGen++;
             window.addEventListener('custom-icons-loaded', this._iconHandler);
             this.setupKioskGesture();
+            this.connectMenuSSE();
             this.startMenuPolling();
             this.scheduleScrollArrowUpdate();
             this._resizeHandler = () => this.updateScrollArrows();
@@ -245,7 +253,7 @@ function menuApp() {
 
         destroy() {
             if (this._svgAbort) { this._svgAbort.abort(); this._svgAbort = null; }
-            if (this._menuPollId) { clearInterval(this._menuPollId); this._menuPollId = null; }
+            if (this._menuSSE) { this._menuSSE.close(); this._menuSSE = null; }
             if (this._visibilityHandler) { document.removeEventListener('visibilitychange', this._visibilityHandler); this._visibilityHandler = null; }
             if (this._statusPollId) { clearInterval(this._statusPollId); this._statusPollId = null; }
             if (this._resizeHandler) { window.removeEventListener('resize', this._resizeHandler); this._resizeHandler = null; }
@@ -360,11 +368,11 @@ function menuApp() {
             }
         },
 
-        async loadMenu() {
+        async loadMenu({ clearOthers = false } = {}) {
             try {
                 const res = await fetch('/api/menu');
                 if (res.ok) {
-                    this.applyMenuData(await res.json());
+                    this.applyMenuData(await res.json(), { clearOthers });
                     this.state = 'ready';
                 } else if (res.status === 404) {
                     // No server menu — check if generation failed
@@ -405,21 +413,29 @@ function menuApp() {
             this.state = 'ready';
         },
 
-        applyMenuData(data) {
+        applyMenuData(data, { clearOthers = false } = {}) {
             const newRecipes = data.recipes || [];
             this.warnings = data.warnings || [];
             this.relaxedConstraints = data.relaxed_constraints || [];
             this.generatedAt = data.generated_at || '';
 
+            const versionChanged = data.version !== this.menuVersion;
+
             if (newRecipes.length > 0) {
                 this.currentRecipes = newRecipes;
 
+                // Scheduled generation with clear_others — fresh start
+                if (clearOthers && versionChanged) {
+                    this.shelves = [];
+                    this.activeDeckName = null;
+                }
+
                 if (this.shelves.length === 0) {
-                    // First load — seed shelf
+                    // First load or cleared — seed shelf
                     const name = data.profile || this.activeProfile || 'Menu';
                     this.addShelf(name, newRecipes);
                     this.activeDeckName = name;
-                } else if (data.version !== this.menuVersion) {
+                } else if (versionChanged) {
                     // Server has a newer menu than what shelves hold — update active shelf
                     const target = data.profile || this.activeDeckName || this.activeProfile || 'Menu';
                     this.addShelf(target, newRecipes);
@@ -451,51 +467,92 @@ function menuApp() {
             // Combined list for carousel
             this.recipes = [...this.currentRecipes, ...this.previousRecipes];
 
-            // Scroll carousel to start on next tick
-            this.$nextTick(() => this.scrollCarouselToStart());
+            // Scroll carousel to start only when content changed
+            if (versionChanged) {
+                this.$nextTick(() => this.scrollCarouselToStart());
+            }
         },
 
-        // ---- Menu Polling (60s version check) ----
+        // ---- Menu SSE (real-time updates) ----
 
+        connectMenuSSE() {
+            if (this._menuSSE) this._menuSSE.close();
+            this._sseRetryDelay = CONST.SSE_INITIAL_RETRY_MS;
+            this._menuSSE = new EventSource('/api/menu/stream');
+
+            this._menuSSE.addEventListener('generating', () => {
+                // Only show spinner on kiosk displays — customers don't need to see it
+                if (this.settings.kiosk_enabled && this.state !== 'generating') {
+                    this.state = 'generating';
+                }
+            });
+
+            this._menuSSE.addEventListener('menu_updated', (e) => {
+                let clearOthers = false;
+                try {
+                    const data = JSON.parse(e.data);
+                    clearOthers = !!data.clear_others;
+                } catch (_) { /* ignore parse errors */ }
+                this._pendingClearOthers = clearOthers;
+                this._debouncedLoadMenu();
+            });
+
+            this._menuSSE.addEventListener('menu_cleared', () => {
+                // On kiosk, clear immediately. On phones, keep current view with stale indicator.
+                if (this.settings.kiosk_enabled) {
+                    this.shelves = [];
+                    this.activeDeckName = null;
+                    this.menuVersion = null;
+                    this.recipes = [];
+                    this.currentRecipes = [];
+                    this.generatedAt = '';
+                    this.saveShelves();
+                    this.state = 'ready';
+                }
+            });
+
+            this._menuSSE.addEventListener('connected', () => {
+                this._sseRetryDelay = CONST.SSE_INITIAL_RETRY_MS;
+                // Sync state on reconnect — may have missed events while disconnected
+                this._debouncedLoadMenu();
+            });
+
+            this._menuSSE.onerror = () => {
+                this._menuSSE.close();
+                setTimeout(() => this.connectMenuSSE(), this._sseRetryDelay);
+                this._sseRetryDelay = Math.min(this._sseRetryDelay * 2, CONST.SSE_MAX_RETRY_MS);
+            };
+        },
+
+        // Debounced menu load — prevents concurrent fetches from rapid SSE events
+        _debouncedLoadMenu() {
+            if (this._loadMenuInFlight) {
+                this._loadMenuPending = true;
+                return;
+            }
+            this._loadMenuInFlight = true;
+            const clearOthers = this._pendingClearOthers || false;
+            this._pendingClearOthers = false;
+            this.loadMenu({ clearOthers }).finally(() => {
+                this._loadMenuInFlight = false;
+                if (this._loadMenuPending) {
+                    this._loadMenuPending = false;
+                    this._debouncedLoadMenu();
+                }
+            });
+        },
+
+        // Fallback: sync on tab visibility (SSE may have disconnected while backgrounded)
         startMenuPolling() {
-            const pollMs = (this.settings.menu_poll_seconds ?? CONST.DEFAULT_MENU_POLL_SECONDS) * 1000;
-            this._menuPollId = setInterval(() => this.checkMenuVersion(), pollMs);
-            // Poll immediately when tab becomes visible (catches updates while backgrounded)
             this._visibilityHandler = () => {
-                if (document.visibilityState === 'visible') this.checkMenuVersion();
+                if (document.visibilityState === 'visible') {
+                    // Only fetch if SSE is disconnected or version might be stale
+                    if (!this._menuSSE || this._menuSSE.readyState !== EventSource.OPEN) {
+                        this._debouncedLoadMenu();
+                    }
+                }
             };
             document.addEventListener('visibilitychange', this._visibilityHandler);
-        },
-
-        async checkMenuVersion() {
-            if (this.state === 'generating') return;
-            try {
-                const res = await fetch('/api/menu');
-                if (res.status === 404) {
-                    // Menu was cleared from admin — clear customer shelves
-                    if (this.menuVersion) {
-                        this.shelves = [];
-                        this.activeDeckName = null;
-                        this.menuVersion = null;
-                        this.recipes = [];
-                        this.currentRecipes = [];
-                        this.saveShelves();
-                    }
-                    return;
-                }
-                if (!res.ok) return;
-                const data = await res.json();
-                if (data.version !== this.menuVersion) {
-                    const target = data.profile || this.activeProfile || 'Menu';
-                    this.addShelf(target, data.recipes || []);
-                    this.activeDeckName = target;
-                    this.menuVersion = data.version;
-                    this.saveShelves();
-                    this.$nextTick(() => this.scrollCarouselToStart());
-                }
-            } catch (e) {
-                // Silent - will retry next interval
-            }
         },
 
         // ---- Generation ----
@@ -633,6 +690,11 @@ function menuApp() {
             return dayjs(isoString).fromNow();
         },
 
+        formatMenuDate(isoString) {
+            if (!isoString) return '';
+            return dayjs(isoString).format('dddd, MMMM D');
+        },
+
         scrollCarouselToStart() {
             const track = this.$refs.carouselTrack;
             if (track) track.scrollTo({ left: 0, behavior: 'smooth' });
@@ -732,11 +794,14 @@ function menuApp() {
                 const res = await fetch('/api/menu');
                 if (res.ok) {
                     const data = await res.json();
-                    const target = this._targetShelf || this.activeProfile || 'Menu';
+                    const target = this._targetShelf || data.profile || this.activeProfile || 'Menu';
                     this._targetShelf = null;
                     this.addShelf(target, data.recipes || []);
                     this.activeDeckName = target;
+                    this.generatedAt = data.generated_at || '';
                     this.menuVersion = data.version;
+                    this.currentRecipes = data.recipes || [];
+                    this.recipes = [...this.currentRecipes, ...this.previousRecipes];
                     this.saveShelves();
                     this.state = 'ready';
                     this.$nextTick(() => this.scrollCarouselToStart());


### PR DESCRIPTION
## Summary
- Real-time menu updates via SSE
- Make-now constraint and custom filters UI (#15)
- Path traversal validation on all file-based services
- Comprehensive test coverage audit (SSE, profiles, solver, state machine)
- Architectural lint tests and narrowed exception handling
- Dependency bumps (ruff, codeql-action, Python 3.14-slim, scorecard permissions)

## Context
Feature branch `feat/makenow-and-custom-filters` merged into develop, resolving divergent `clear_before_generate` implementations (took the `clear_others` flag pattern from the feature branch).