### PR TITLE
fix(ci): push workflow permissions for reusable ci.yml

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   ci:


### PR DESCRIPTION
## Summary

- Adds `packages: write` to push.yml's top-level permissions so the reusable ci.yml's `push-develop` job doesn't exceed the caller's permission ceiling
- Fixes `startup_failure` on main push after PR #48 merge

## Test plan

- [ ] Push workflow completes on main (no startup_failure)
- [ ] GHCR image built and tagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)