### PR TITLE
fix: Tandoor Next compatibility, SSE auth spam, menu date

### DIFF
--- a/morsl/tandoor_api.py
+++ b/morsl/tandoor_api.py
@@ -100,7 +100,20 @@ class TandoorAPI:
                     f"{response.status_code}: {response.text}"
                 )
                 raise TandoorAPIError(response.status_code, response.text)
-            content = json.loads(response.content)
+            try:
+                content = json.loads(response.content)
+            except json.JSONDecodeError as e:
+                body_preview = response.text[:200] if response.text else "(empty)"
+                self.logger.error(
+                    f"Tandoor returned non-JSON from {url} "
+                    f"(status={response.status_code}, "
+                    f"content-type={response.headers.get('content-type', 'unknown')}): "
+                    f"{body_preview}"
+                )
+                raise TandoorAPIError(
+                    response.status_code,
+                    f"Non-JSON response from {url}: {body_preview}",
+                ) from e
             new_results = content.get("results", [])
             self.logger.debug(f"Retrieved {len(new_results)} results.")
             results.extend(new_results)
@@ -134,7 +147,7 @@ class TandoorAPI:
 
     @cached
     def get_unpaged_results(self, url: str, obj_id: Union[str, int], **kwargs) -> Dict[str, Any]:
-        url = f"{url}{obj_id}"
+        url = f"{url}{obj_id}/"
         self.logger.debug(f"Connecting to tandoor api at url: {url}")
         response = self.session.get(url, timeout=DEFAULT_TIMEOUT)
 
@@ -143,7 +156,19 @@ class TandoorAPI:
                 f"Failed to fetch recipes. Status code: {response.status_code}: {response.text}"
             )
             raise TandoorAPIError(response.status_code, response.text)
-        return json.loads(response.content)
+        try:
+            return json.loads(response.content)
+        except json.JSONDecodeError as e:
+            body_preview = response.text[:200] if response.text else "(empty)"
+            self.logger.error(
+                f"Tandoor returned non-JSON from {url} "
+                f"(content-type={response.headers.get('content-type', 'unknown')}): "
+                f"{body_preview}"
+            )
+            raise TandoorAPIError(
+                response.status_code,
+                f"Non-JSON response from {url}: {body_preview}",
+            ) from e
 
     def create_object(self, url: str, data: Dict[str, Any], **kwargs) -> Dict[str, Any]:
         self.logger.debug(f"Create object with tandoor api at url: {url}")
@@ -228,7 +253,7 @@ class TandoorAPI:
         Returns:
             dict: Details of the recipe in JSON-LD format.
         """
-        url = f"{self.url}recipe/{recipe_id}"
+        url = f"{self.url}recipe/{recipe_id}/"
         response = self.session.get(url, timeout=DEFAULT_TIMEOUT)
 
         if response.status_code == 200:

--- a/web/js/admin.js
+++ b/web/js/admin.js
@@ -1730,9 +1730,19 @@ function adminApp() {
             } catch (e) { /* silent */ }
         },
 
-        connectOrderSSE() {
+        async connectOrderSSE() {
             if (this._orderSSE) this._orderSSE.close();
             this._sseRetryDelay = CONST.SSE_INITIAL_RETRY_MS;
+
+            // Pre-flight auth check — don't open EventSource if we can't auth
+            try {
+                const check = await this.adminFetch('/api/orders/stream', { method: 'HEAD' });
+                if (check.status === 401 || check.status === 403) {
+                    console.warn('Order SSE auth failed, not connecting');
+                    return;
+                }
+            } catch { /* network error — try SSE anyway */ }
+
             this._orderSSE = new EventSource('/api/orders/stream');
             this._orderSSE.addEventListener('order', (e) => {
                 try {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -468,12 +468,12 @@ function menuApp() {
                 if (this.shelves.length === 0) {
                     // First load or cleared — seed shelf
                     const name = data.profile || this.activeProfile || 'Menu';
-                    this.addShelf(name, newRecipes);
+                    this.addShelf(name, newRecipes, data.generated_at);
                     this.activeDeckName = name;
                 } else if (versionChanged) {
                     // Server has a newer menu than what shelves hold — update active shelf
                     const target = data.profile || this.activeDeckName || this.activeProfile || 'Menu';
-                    this.addShelf(target, newRecipes);
+                    this.addShelf(target, newRecipes, data.generated_at);
                     this.activeDeckName = target;
                     this.saveShelves();
                 }
@@ -855,7 +855,7 @@ function menuApp() {
                     }
                     const target = this._targetShelf || data.profile || this.activeProfile || 'Menu';
                     this._targetShelf = null;
-                    this.addShelf(target, data.recipes || []);
+                    this.addShelf(target, data.recipes || [], data.generated_at);
                     this.activeDeckName = target;
                     this.generatedAt = data.generated_at || '';
                     this.menuVersion = data.version;
@@ -876,11 +876,11 @@ function menuApp() {
             }
         },
 
-        addShelf(name, recipes) {
+        addShelf(name, recipes, generatedAt) {
             this._carouselCache = null;
             this._carouselCacheKey = null;
             const existing = this.shelves.find(s => s.name === name);
-            const generation = { recipes, generatedAt: new Date().toISOString() };
+            const generation = { recipes, generatedAt: generatedAt || new Date().toISOString() };
             if (existing) {
                 // Prepend new generation, cap at max
                 existing.generations.unshift(generation);


### PR DESCRIPTION
## Summary

- **Tandoor Next generation fix** — add trailing slashes to API detail endpoint URLs. Django's `APPEND_SLASH` redirect was dropping the `Authorization` header, causing Tandoor to return HTML instead of JSON.
- **JSON error diagnostics** — `get_paged_results` and `get_unpaged_results` now log URL, status, content-type, and response preview when Tandoor returns non-JSON.
- **SSE 401 spam fix** — admin order stream pre-checks auth before opening EventSource, preventing tight reconnect loop that flooded logs.
- **Menu date fix** — shelf generation date now uses server's `generated_at` timestamp instead of client clock.

## Test plan

- [x] 475 tests pass
- [x] Generation confirmed working against Tandoor Next (preview branch) in prod
- [x] CI green on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)