### PR TITLE
chore(deps): cover web-vue/ with npm dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,29 @@ updates:
     labels:
       - dependencies
 
+  # web-vue/ was previously uncovered: no npm ecosystem meant the Vite
+  # frontend got no version updates at all, so its lockfile drifted until
+  # 7 advisories accumulated with no PR ever opened for them.
+  - package-ecosystem: npm
+    directory: /web-vue
+    target-branch: develop
+    schedule:
+      interval: weekly
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      npm-patches:
+        update-types: ["patch"]
+      npm-minors:
+        update-types: ["minor"]
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - dependencies
+
   - package-ecosystem: docker
     directory: /
     target-branch: develop


### PR DESCRIPTION
Closes the config gap behind morsl's 7 open Dependabot alerts.

## The gap

`dependabot.yml` declared `pip`, `github-actions` and `docker` — **no `npm`**. The Vite frontend in `web-vue/` therefore received no version updates at all, and its lockfile drifted until 7 advisories accumulated with no PR ever opened for any of them.

All 7 alerts resolve to `web-vue/package-lock.json`: 6 high (`vite` `server.fs.deny` bypass, `postcss` x2, `ws`, `js-cookie`, `brace-expansion`) and 1 medium (`launch-editor`). These are build/dev-time dependencies, not the runtime server, so real exposure is low — but the repo was alerting with no remediation path, which is the worst of both.

To be explicit: **auto-merge was never the problem.** Eleven Dependabot PRs merged automatically in July (#92–#101). Nothing was stuck; nothing was ever opened.

## Two separate fixes

1. **Dependabot security updates were disabled** on the repo (`automated-security-fixes: enabled: false`) while vulnerability alerts were on — so we could see CVEs but never got PRs for them. Enabled separately via the API; that is what should clear the existing 7.
2. **This PR** adds the missing `npm` ecosystem so the gap cannot reopen for routine version drift.

## Why `target-branch: develop`

Matches the three existing entries, and it matters more than style here: `push.yml`'s `auto-release` job is **unguarded** — it bumps the patch version and pushes a tag, GHCR image and GitHub release on *any* push to `main`, with no version check or `paths-ignore`. Routine dependency bumps landing on `main` would each cut a release.

Grouped patch/minor with the same cooldown and commit-message conventions as the `pip` entry.

## Verified

`dependabot.yml` parses as valid YAML with 4 ecosystems; all 7 alert manifest paths confirmed as `web-vue/package-lock.json` before choosing `directory: /web-vue`.

## Open item

Whether `target-branch` suppresses npm *security* update PRs is not clearly documented either way, so I have not asserted it. Since security updates were just enabled, this is directly observable: if no security PRs appear for the 7 alerts within a day or so, the fix is to drop `target-branch` from the `npm` entry only.