### PR TITLE
chore(deps): activate npm dependabot entry on main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,29 @@ updates:
     labels:
       - dependencies
 
+  # web-vue/ was previously uncovered: no npm ecosystem meant the Vite
+  # frontend got no version updates at all, so its lockfile drifted until
+  # 7 advisories accumulated with no PR ever opened for them.
+  - package-ecosystem: npm
+    directory: /web-vue
+    target-branch: develop
+    schedule:
+      interval: weekly
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      npm-patches:
+        update-types: ["patch"]
+      npm-minors:
+        update-types: ["minor"]
+    commit-message:
+      prefix: chore
+      include: scope
+    labels:
+      - dependencies
+
   - package-ecosystem: docker
     directory: /
     target-branch: develop


### PR DESCRIPTION
Brings #108's `npm` / `/web-vue` entry to `main`. Only `.github/dependabot.yml` changes.

**Why it has to be on main:** Dependabot reads `dependabot.yml` from the default branch, so the npm *version* updates added in #108 are inert while they sit only on `develop`. (Security updates are dependency-graph driven and need no config, which is why #104–#107 appeared without this.)

**Doubles as the first live test of the release guard from #109.** This push touches nothing but `.github/dependabot.yml`, which is on the deny-list, so `changes` should report `shippable=false` and `auto-release` / `build-and-scan` / `push-image` / `github-release` should all skip while `ci` and `coverage` still run. If a v0.3.6 appears, the guard is wrong and I will revert it.